### PR TITLE
helpers: Add uwu-tools/magex

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A collection of awesome Mage and Magefile resources
 + [repoman](https://github.com/cabify/repoman) - Repository Manager Support Package.
 
 ### Mage Helpers and Examples
++ [uwu-tools/magex](https://github.com/uwu-tools/magex) - Helper methods for magefiles
 + [Beats Mage Helpers](https://github.com/elastic/beats/tree/master/dev-tools/mage) - Extensive and well maintained helpers for many purposes.
 + [repoman](https://github.com/cabify/repoman) - Repository Manager Support Package, grouping and syncing repositories
 + [mage-loot](https://github.com/aserto-dev/mage-loot) - Mage dependency management using `Depfile`, and helper functions for `buf`, `protoc`, linting, code-gen, and others


### PR DESCRIPTION
Adding a reference to [uwu-tools/magex](https://github.com/uwu-tools/magex), a helper library used in Kubernetes Release Engineering projects and [Project Stacker](https://github.com/project-stacker/stacker-bom).

(Additional dependents listed [here](https://github.com/uwu-tools/magex/network/dependents?dependent_type=REPOSITORY)).

cc: @StevenACoffman